### PR TITLE
Disallow leading 0s

### DIFF
--- a/vup-cli/tests/cli.rs
+++ b/vup-cli/tests/cli.rs
@@ -161,3 +161,28 @@ fn test_empty_stdin() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+/// Test numbers with leading 0s fail.
+#[test]
+fn test_leading_0s() -> Result<(), Box<dyn std::error::Error>> {
+    let tests = [
+        "01.1.1",
+        "000000000001.1.1",
+        "1.01.1",
+        "1.1.01",
+        "1.000000000000000000000000000000000000000000000000001.1",
+        "00.1.1",
+    ];
+
+    for test in tests {
+        for bump in ["major", "minor", "patch"] {
+            Command::cargo_bin("vup")?
+                .arg(bump)
+                .write_stdin(test)
+                .assert()
+                .failure();
+        }
+    }
+
+    Ok(())
+}

--- a/vup/src/semver.rs
+++ b/vup/src/semver.rs
@@ -137,6 +137,10 @@ where
 {
     log::trace!("Parsing number from {string:?}.");
 
+    if string.len() > 1 && string.starts_with('0') {
+        return Err(ParseError::InvalidNumber);
+    }
+
     let Ok(number) = string.parse::<T>() else {
         log::error!("Could not parse number from {string:?}.");
         return Err(ParseError::InvalidNumber);

--- a/vup/src/semver.rs
+++ b/vup/src/semver.rs
@@ -129,8 +129,9 @@ pub fn parse(string: &str) -> Result<Version, ParseError> {
 
 /// Parse a number from a string.
 ///
-/// This is just a wrapper around the builtin `parse` method of `str` except it
-/// adds some logging and error information.
+/// Valid numbers can only contain digit characters and may not start with a
+/// `'0'` unless it is the only character in the number (meaning `"0"` is OK but
+/// `"00"` and `"01"` are not, for example).
 fn parse_number<T>(string: &str) -> Result<T, ParseError>
 where
     T: FromStr,


### PR DESCRIPTION
This addresses #1: fail when a core SemVer version component starts with a `'0'` (and isn't just `"0"`). 